### PR TITLE
Some fixes

### DIFF
--- a/src/LaTeX.cpp
+++ b/src/LaTeX.cpp
@@ -203,14 +203,14 @@ LaTeX::getHeaderGenerics()
   mOutputFile << "&";
 
   if (cfg.getBool("Table.boldHeadings"))
-    writeCell(colNames::Direction,
-              cfg.getString("Table.Direction_heading"),
+    writeCell(colNames::DefaultValue,
+              cfg.getString("Table.GenericDefaultValue"),
               " \\textbf{",
               "} ",
               " ");
   else
-    writeCell(colNames::Direction,
-              cfg.getString("Table.Direction_heading"),
+    writeCell(colNames::DefaultValue,
+              cfg.getString("Table.GenericDefaultValue"),
               " ",
               " ",
               " ");

--- a/src/LaTeX.cpp
+++ b/src/LaTeX.cpp
@@ -100,7 +100,7 @@ LaTeX::getTable()
   getHeaderPorts();
   getPorts();
 
-  if (cfg.getBool("Table.exportGenerics")) {
+  if (cfg.getBool("Table.exportGenerics") && mSourceEntity.getNumberOfGenerics() > 0) {
     if (cfg.getBool("LaTeX.addTable"))
       mOutputFile << "\\vspace*{ 1 em }" << std::endl << std::endl;
 

--- a/src/SVG.cpp
+++ b/src/SVG.cpp
@@ -291,6 +291,8 @@ SVG::translate()
 
     // Close group for generics
     mWriter.group(1);
+  } else {
+    currentY = currentY - 1 + strokeWidth + 0.02;
   }
 
   // Open group for entity


### PR DESCRIPTION
- latex generic tables were exported when empty
- table heading of generic default value was set to Direction instead of Default Value
- SVGs without generic entities had too much space above the entity box